### PR TITLE
fix: readme path URI encoding

### DIFF
--- a/packages/gitlab/src/api/GitlabCIClient.ts
+++ b/packages/gitlab/src/api/GitlabCIClient.ts
@@ -317,7 +317,7 @@ export class GitlabCIClient implements GitlabCIApi {
         if (filePath.startsWith('./')) filePath = filePath.slice(2);
 
         const readmeStr = await this.callApi<string>(
-            `projects/${projectID}/repository/files/${encodeURI(filePath)}/raw`,
+            `projects/${projectID}/repository/files/${encodeURIComponent(filePath)}/raw`,
             { ref: branch }
         );
 


### PR DESCRIPTION
## 🚨 Proposed changes

> Please review the [guidelines for contributing](../../CONTRIBUTING.md) to this repository.

[[Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.]]

## ⚙️ Types of changes

- Change URI encoding function to support relative paths

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor


## Additional context


Hello world,

First of all, thank you for a great plugin!

I noticed unexpected behavior of the README.md component. I have a monorepo where each folder is a standalone component (terraform module in my case). I was able to successfully import modules to Backstage using Location (on the root level) and Component (spec type=library inside each folder)


```
# root level:
README.md
catalog-info.yml

module-a/
module-a/README.md
module-a/catalog-info.yml

module-b/
module-b/README.md
module-b/catalog-info.yml
```

As you can see, every module has its own README, and I was trying to pass the readme annotation:

```
gitlab.com/readme-path: module-a/README.md
```

This annotation was translated to following url:
```
curl 'https://<my-backstage-instance-domain>/api/gitlab/gitlab.com/projects/<GITLAB_PROJECT_ID>/repository/files/module-a/README.md/raw?ref=develop'
```

and this request failed with 404. Upon checking Gitlab docs

https://docs.gitlab.com/ee/api/repository_files.html

I noticed that path must be URL encoded and correct URL would be like this:

```
curl 'https://<my-backstage-instance-domain>/api/gitlab/gitlab.com/projects/<GITLAB_PROJECT_ID>/repository/files/module-a%2FREADME.md/raw?ref=develop'
```

(`/` -> `%2F`)

However, it's not happening in the current plugin version.

When I tried to replace the annotation path with already encoded version, it was encoded again

```
gitlab.com/readme-path: module-a%2FREADME.md
```

resulting in the following cURL request:

```
curl 'https:///<my-backstage-instance-domain>/api/gitlab/gitlab.com/projects/<GITLAB_PROJECT_ID>/repository/files/module-a%252FREADME.md/raw?ref=main' 
```

Either approaches don't work correctly.

More context https://stackoverflow.com/questions/4540753/should-i-use-encodeuri-or-encodeuricomponent-for-encoding-urls

That said, I believe `encodeURIComponent` will serve the purpose and allow correct relative paths


That's it!
Thank you <3